### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,17 +15,17 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_PAT }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.1.0
+        uses: docker/setup-buildx-action@v3.2.0
 
       - name: Cache Docker layers
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4.0.2
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Build and push Docker image to GHCR
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v5.3.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.1.0](https://github.com/docker/login-action/releases/tag/v3.1.0)** on 2024-03-13T15:11:17Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.2.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.2.0)** on 2024-03-14T08:24:16Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v5.3.0](https://github.com/docker/build-push-action/releases/tag/v5.3.0)** on 2024-03-14T08:32:47Z
