### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.2
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3.3.0
@@ -22,10 +22,10 @@ jobs:
           password: ${{ secrets.GHCR_PAT }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.6.1
+        uses: docker/setup-buildx-action@v3.8.0
 
       - name: Build and push Docker image to GHCR
-        uses: docker/build-push-action@v6.7.0
+        uses: docker/build-push-action@v6.12.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.GHCR_PAT }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.12.0](https://github.com/docker/build-push-action/releases/tag/v6.12.0)** on 2025-01-15T12:58:27Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.8.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.8.0)** on 2024-12-16T09:47:41Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
