### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,21 +15,21 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_PAT }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.8.0
+        uses: docker/setup-buildx-action@v3.10.0
         id: buildx
         with:
           version: latest
           buildkitd-flags: --debug
 
       - name: Cache Docker layers
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@v4.2.3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Build and push Docker image to GHCR
-        uses: docker/build-push-action@v6.12.0
+        uses: docker/build-push-action@v6.17.0
         with:
           context: .
           file: ./Dockerfile
@@ -77,6 +77,6 @@ jobs:
           curl -X POST ${{ secrets.PORTAINER_WEBHOOK_URL_DEV2 }}
 
       - name: Scan for vulnerabilities
-        uses: crazy-max/ghaction-container-scan@v3
+        uses: crazy-max/ghaction-container-scan@v3.1.0
         with:
           image: ghcr.io/${{ github.repository_owner }}/docker-qbittorrentvpn:${{ github.ref == 'refs/heads/main' && 'latest' || github.ref_name }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.10.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.10.0)** on 2025-02-26T15:36:31Z
* **[crazy-max/ghaction-container-scan](https://github.com/crazy-max/ghaction-container-scan)** published a new release **[v3.1.0](https://github.com/crazy-max/ghaction-container-scan/releases/tag/v3.1.0)** on 2025-03-29T00:30:28Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.4.0](https://github.com/docker/login-action/releases/tag/v3.4.0)** on 2025-03-14T09:53:25Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.17.0](https://github.com/docker/build-push-action/releases/tag/v6.17.0)** on 2025-05-15T12:49:16Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.3](https://github.com/actions/cache/releases/tag/v4.2.3)** on 2025-03-19T18:18:32Z
